### PR TITLE
Modify to be compiled with haxe4 compiler

### DIFF
--- a/knockout/BindingContext.hx
+++ b/knockout/BindingContext.hx
@@ -2,14 +2,14 @@ package knockout;
 
 extern class BindingContext {
 
-    public var parent(get_parent, null):Null<Dynamic>;
-    public var parents(get_parents, null):Null<Array<Dynamic>>;
-    public var root(get_root, null):Dynamic;
-    public var data(get_data, null):Null<Dynamic>;
-    public var index(get_index, null):Null<Int>;
-    public var parentContext(get_parentContext, null):Null<BindingContext>;
-    public var context(get_context, null):BindingContext;
-    public var element(get_element, null):js.html.Node;
+    public var parent(get, null):Null<Dynamic>;
+    public var parents(get, null):Null<Array<Dynamic>>;
+    public var root(get, null):Dynamic;
+    public var data(get, null):Null<Dynamic>;
+    public var index(get, null):Null<Int>;
+    public var parentContext(get, null):Null<BindingContext>;
+    public var context(get, null):BindingContext;
+    public var element(get, null):js.html.Node;
 
     private inline function get_parent():Null<Dynamic> untyped {
         return this["$parent"];


### PR DESCRIPTION
With a haxe4 compiler, `haxe compile.hxml` fails with the following outputs:
```
knockout/BindingContext.hx:6: characters 24-35 : parents: Custom property accessor is no longer supported, please use `get`
knockout/BindingContext.hx:7: characters 21-29 : root: Custom property accessor is no longer supported, please use `get`
knockout/BindingContext.hx:8: characters 21-29 : data: Custom property accessor is no longer supported, please use `get`
knockout/BindingContext.hx:9: characters 22-31 : index: Custom property accessor is no longer supported, please use `get`
knockout/BindingContext.hx:10: characters 30-47 : parentContext: Custom property accessor is no longer supported, please use `get`
knockout/BindingContext.hx:11: characters 24-35 : context: Custom property accessor is no longer supported, please use `get`
knockout/BindingContext.hx:12: characters 24-35 : element: Custom property accessor is no longer supported, please use `get`
```

This PR fixes the problem.